### PR TITLE
Extract linter_name from payload

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -18,7 +18,7 @@ Linter.prototype.lint = function(payload) {
       return this.houndJavascript.reportInvalidConfig({
         pull_request_number: payload.pull_request_number,
         commit_sha: payload.commit_sha,
-        linter_name: "jscs",
+        linter_name: payload.linter_name,
         message: "Error parsing config for: jscs. " + exception.message
       });
     }
@@ -31,6 +31,7 @@ Linter.prototype.lint = function(payload) {
     return this.houndJavascript.completeFileReview({
       violations: violations,
       filename: payload.filename,
+      linter_name: payload.linter_name,
       commit_sha: payload.commit_sha,
       pull_request_number: payload.pull_request_number,
       patch: payload.patch,
@@ -39,7 +40,7 @@ Linter.prototype.lint = function(payload) {
     return this.houndJavascript.reportInvalidConfig({
       pull_request_number: payload.pull_request_number,
       commit_sha: payload.commit_sha,
-      linter_name: "jscs",
+      linter_name: payload.linter_name,
     });
   }
 };

--- a/tests/linter-test.js
+++ b/tests/linter-test.js
@@ -10,6 +10,7 @@ asyncTest("JSCS linting", function() {
     content: "// TODO",
     config: "{ \"disallowKeywordsInComments\": true }",
     filename: "filename",
+    linter_name: "hound_assigned_name",
     commit_sha: "commit_sha",
     pull_request_number: "pull_request_number",
     patch: "patch",
@@ -37,6 +38,7 @@ asyncTest("JSCS linting", function() {
             },
           ],
           filename: "filename",
+          linter_name: "hound_assigned_name",
           commit_sha: "commit_sha",
           pull_request_number: "pull_request_number",
           patch: "patch",
@@ -52,6 +54,7 @@ asyncTest("JSCS linting with an unknown preset", function() {
     content: "// TODO",
     config: "{ \"preset\": \"unknown-preset\" }",
     filename: "filename",
+    linter_name: "hound_assigned_name",
     commit_sha: "commit_sha",
     pull_request_number: "pull_request_number",
     patch: "patch",
@@ -74,7 +77,7 @@ asyncTest("JSCS linting with an unknown preset", function() {
         {
           pull_request_number: "pull_request_number",
           commit_sha: "commit_sha",
-          linter_name: "jscs",
+          linter_name: "hound_assigned_name",
           message: "Error parsing config for: jscs. Preset \"unknown-preset\" does not exist",
         },
         "pushes a job onto the queue"
@@ -88,6 +91,7 @@ asyncTest("Reporting an invalid configuration file", function() {
     content: "// TODO",
     config: "---\nyaml: is good\ntrue/false/syntax/error",
     filename: "filename",
+    linter_name: "hound_assigned_name",
     commit_sha: "commit_sha",
     pull_request_number: "pull_request_number",
     patch: "patch",
@@ -110,7 +114,7 @@ asyncTest("Reporting an invalid configuration file", function() {
         {
           commit_sha: "commit_sha",
           pull_request_number: "pull_request_number",
-          linter_name: "jscs",
+          linter_name: "hound_assigned_name",
         },
         "pushes a job onto the queue"
       );


### PR DESCRIPTION
[Related Hound pull](https://github.com/houndci/hound/pull/1102)

It is possible for Hound to assign more than one linter to review a single file
in a build. Because of this, when Hound dequeues an incoming
CompletedFileReview, it needs to know both the name of the file linted and the
linter reporting any errors.

This change updates the JSCS linter to look for a linter_name key in the
payload object dequeued from Redis. It then passes the linter name back either
upon successful completion of a review or when upon detecting a
configuration error.